### PR TITLE
Triggers Docker Hub updates on tags

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,8 +2,8 @@ name: Build and Push Docker Image
 
 on:
   push:
-    branches:
-      - release
+    tags:
+      - 'v*'
   workflow_dispatch:
 
 env:
@@ -58,7 +58,7 @@ jobs:
             VERSION=${{ steps.meta.outputs.version }}
 
       - name: Update Docker Hub description
-        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/release'
+        if: startsWith(github.ref, 'refs/tags/')
         uses: peter-evans/dockerhub-description@v4
         continue-on-error: true
         with:


### PR DESCRIPTION
Updates the Docker Hub description only when new tags are pushed, rather than when changes are merged into the release branch. This ensures that the Docker Hub description is updated only for stable releases.
