### PR TITLE
Replace Overseerr template with Seerr

### DIFF
--- a/internal/handlers/dashboard.go
+++ b/internal/handlers/dashboard.go
@@ -176,7 +176,7 @@ func (h *DashboardHandlers) ShowDashboard(w http.ResponseWriter, r *http.Request
 	data["HasSonarr"] = installed["sonarr"]
 	data["HasRadarr"] = installed["radarr"]
 	data["HasQBittorrent"] = installed["qbittorrent"]
-	data["HasOverseerr"] = installed["overseerr"]
+	data["HasSeerr"] = installed["seerr"]
 	data["HasSabnzbd"] = installed["sabnzbd"]
 	data["HasProwlarr"] = installed["prowlarr"]
 	data["HasBazarr"] = installed["bazarr"]

--- a/internal/services/templates.go
+++ b/internal/services/templates.go
@@ -107,16 +107,16 @@ func NewRegistry() *Registry {
 					"WEBUI_PORT": "8080",
 				},
 			},
-			"overseerr": {
-				Name:        "Overseerr",
+			"seerr": {
+				Name:        "Seerr",
 				Description: "Request management and media discovery",
-				IconURL:     "https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/overseerr.png",
-				Image:       "lscr.io/linuxserver/overseerr:latest",
+				IconURL:     "https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/seerr.png",
+				Image:       "ghcr.io/hotio/seerr:latest",
 				DefaultPorts: []database.PortMapping{
-					{Host: 5055, Container: 5055, Protocol: "tcp"},
+					{Host: 5056, Container: 5055, Protocol: "tcp"},
 				},
 				DefaultVolumes: []database.VolumeMapping{
-					{Host: "/mnt/docker/overseerr/config", Container: "/config"},
+					{Host: "/mnt/docker/seerr/config", Container: "/app/config"},
 				},
 				DefaultEnvVars: map[string]string{
 					"PUID": "1000",

--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -160,12 +160,12 @@ docker ps</code></div>
                     <div class="service-description">BitTorrent client with web interface</div>
                 </div>
 
-                <!-- Overseerr -->
-                <div class="service-card {{if .HasOverseerr}}installed{{end}}" {{if not .HasOverseerr}}onclick="window.location.href='/containers/add?template=overseerr'"{{end}}>
+                <!-- Seerr -->
+                <div class="service-card {{if .HasSeerr}}installed{{end}}" {{if not .HasSeerr}}onclick="window.location.href='/containers/add?template=seerr'"{{end}}>
                     <div class="service-icon">
-                        <img src="https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/overseerr.png" alt="Overseerr" style="width: 100%; height: 100%; object-fit: contain; border-radius: 12px;">
+                        <img src="https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/seerr.png" alt="Seerr" style="width: 100%; height: 100%; object-fit: contain; border-radius: 12px;">
                     </div>
-                    <div class="service-name">Overseerr</div>
+                    <div class="service-name">Seerr</div>
                     <div class="service-description">Request management and media discovery</div>
                 </div>
 


### PR DESCRIPTION
## Summary
- Replaced the deprecated Overseerr quick start template with Seerr
- Uses the hotio/seerr Docker image which supports PUID/PGID permission handling
- Default host port set to 5056 to avoid conflicts with existing Overseerr installs

## Test plan
- [x] App builds and starts without errors
- [x] Seerr card appears on dashboard in Quick Start section
- [x] Clicking Seerr card pre-fills container form with correct defaults
- [x] Seerr container starts successfully with hotio image